### PR TITLE
Intercept template config

### DIFF
--- a/app/code/community/Iterable/TrackOrderPlaced/Block/Adminhtml/System/Config/Form/Field/Campaigns.php
+++ b/app/code/community/Iterable/TrackOrderPlaced/Block/Adminhtml/System/Config/Form/Field/Campaigns.php
@@ -1,14 +1,7 @@
 <?php
 
-/**
- * Create map used in admin config
- * Template_name => campaign_id
- *
- * Class Iterable_TrackOrderPlaced_Block_Adminhtml_System_Config_Form_Field_Interceptlist
- * @author Lucas van Staden (sales@proxiblue.com.au)
- */
 
-class Iterable_TrackOrderPlaced_Block_Adminhtml_System_Config_Form_Field_Interceptlist
+class Iterable_TrackOrderPlaced_Block_Adminhtml_System_Config_Form_Field_Campaigns
     extends Mage_Adminhtml_Block_System_Config_Form_Field_Array_Abstract
 {
     public function __construct()

--- a/app/code/community/Iterable/TrackOrderPlaced/Block/Adminhtml/System/Config/Form/Field/Events.php
+++ b/app/code/community/Iterable/TrackOrderPlaced/Block/Adminhtml/System/Config/Form/Field/Events.php
@@ -1,0 +1,29 @@
+<?php
+
+
+class Iterable_TrackOrderPlaced_Block_Adminhtml_System_Config_Form_Field_Events
+    extends Mage_Adminhtml_Block_System_Config_Form_Field_Array_Abstract
+{
+    public function __construct()
+    {
+        $this->addColumn('template', array(
+            'label' => Mage::helper('trackorderplaced')->__('Template Name'),
+            'style' => 'width:200px',
+        ));
+        $this->addColumn('event_name', array(
+            'label' => Mage::helper('trackorderplaced')->__('Event Name'),
+            'style' => 'width:300px',
+        ));
+        $this->addColumn('campaign_id', array(
+            'label' => Mage::helper('trackorderplaced')->__('Campaign ID (optional)'),
+            'style' => 'width:50px',
+        ));
+        $this->addColumn('template_id', array(
+            'label' => Mage::helper('trackorderplaced')->__('Template ID (optional)'),
+            'style' => 'width:50px',
+        ));
+        $this->_addAfter = false;
+        $this->_addButtonLabel = Mage::helper('trackorderplaced')->__('Add New');
+        parent::__construct();
+    }
+}

--- a/app/code/community/Iterable/TrackOrderPlaced/Block/Adminhtml/System/Config/Form/Field/Interceptlist.php
+++ b/app/code/community/Iterable/TrackOrderPlaced/Block/Adminhtml/System/Config/Form/Field/Interceptlist.php
@@ -1,0 +1,21 @@
+<?php
+
+
+class Iterable_TrackOrderPlaced_Block_Adminhtml_System_Config_Form_Field_Interceptlist
+    extends Mage_Adminhtml_Block_System_Config_Form_Field_Array_Abstract
+{
+    public function __construct()
+    {
+        $this->addColumn('template', array(
+            'label' => Mage::helper('trackorderplaced')->__('Template Name'),
+            'style' => 'width:300px',
+        ));
+        $this->addColumn('campaign_id', array(
+            'label' => Mage::helper('trackorderplaced')->__('Campaign ID'),
+            'style' => 'width:300px',
+        ));
+        $this->_addAfter = false;
+        $this->_addButtonLabel = Mage::helper('trackorderplaced')->__('Add New');
+        parent::__construct();
+    }
+}

--- a/app/code/community/Iterable/TrackOrderPlaced/Block/Adminhtml/System/Config/Form/Field/Interceptlist.php
+++ b/app/code/community/Iterable/TrackOrderPlaced/Block/Adminhtml/System/Config/Form/Field/Interceptlist.php
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ * Create map used in admin config
+ * Template_name => campaign_id
+ *
+ * Class Iterable_TrackOrderPlaced_Block_Adminhtml_System_Config_Form_Field_Interceptlist
+ * @author Lucas van Staden (sales@proxiblue.com.au)
+ */
 
 class Iterable_TrackOrderPlaced_Block_Adminhtml_System_Config_Form_Field_Interceptlist
     extends Mage_Adminhtml_Block_System_Config_Form_Field_Array_Abstract

--- a/app/code/community/Iterable/TrackOrderPlaced/Helper/Data.php
+++ b/app/code/community/Iterable/TrackOrderPlaced/Helper/Data.php
@@ -1,106 +1,69 @@
 <?php
 
-class Iterable_TrackOrderPlaced_Helper_Data extends Mage_Core_Helper_Abstract {
-    
+class Iterable_TrackOrderPlaced_Helper_Data extends Mage_Core_Helper_Abstract
+{
+
     const XML_PATH_ITERABLE_API_KEY = 'api_options/api_key_options/api_key';
     const XML_PATH_ENABLED_EVENTS = 'advanced_options/tracking_options/enabled_events';
 
-    /** transactional email xml config */
-
-    // account created
-    const XML_PATH_TRANSACTIONAL_ACCOUNT_CREATED_ENABLED = 'transactional_email_options/account_created/is_enabled';
-    const XML_PATH_TRANSACTIONAL_ACCOUNT_CREATED_CAMPAIGN_ID = 'transactional_email_options/account_created/campaign_id';
-    const XML_PATH_TRANSACTIONAL_FORGOT_PASSWORD_ENABLED = 'transactional_email_options/forgot_password/is_enabled';
-    const XML_PATH_TRANSACTIONAL_FORGOT_PASSWORD_CAMPAIGN_ID = 'transactional_email_options/forgot_password/campaign_id';
-    const XML_PATH_TRANSACTIONAL_NEWSLETTER_SUBSCRIBE_ENABLED = 'transactional_email_options/newsletter_subscribe/is_enabled';
-    const XML_PATH_TRANSACTIONAL_NEWSLETTER_SUBSCRIBE_CAMPAIGN_ID = 'transactional_email_options/newsletter_subscribe/campaign_id';
-    const XML_PATH_TRANSACTIONAL_NEWSLETTER_UNSUBSCRIBE_ENABLED = 'transactional_email_options/newsletter_unsubscribe/is_enabled';
-    const XML_PATH_TRANSACTIONAL_NEWSLETTER_UNSUBSCRIBE_CAMPAIGN_ID = 'transactional_email_options/newsletter_unsubscribe/campaign_id';
-
-    // disabled section
-    const XML_PATH_TRANSACTIONAL_ORDER_CONFIRM_DISABLED = 'transactional_email_options/order_confirm/is_disabled';
-
-    /** end transactional email xml config */
-
-    /** @var array Map of templateName -> (enabled, campaignId) */
-    private static $EMAIL_TEMPLATE_NAMES_TO_TRANSACTIONAL_EMAIL_OPTIONS = array(
-        'customer_create_account_email_template' => array(
-            self::XML_PATH_TRANSACTIONAL_ACCOUNT_CREATED_ENABLED,
-            self::XML_PATH_TRANSACTIONAL_ACCOUNT_CREATED_CAMPAIGN_ID
-        ),
-        'customer_password_forgot_email_template' => array(
-            self::XML_PATH_TRANSACTIONAL_FORGOT_PASSWORD_ENABLED,
-            self::XML_PATH_TRANSACTIONAL_FORGOT_PASSWORD_CAMPAIGN_ID
-        ),
-        'newsletter_subscription_success_email_template' => array(
-            self::XML_PATH_TRANSACTIONAL_NEWSLETTER_SUBSCRIBE_ENABLED,
-            self::XML_PATH_TRANSACTIONAL_NEWSLETTER_SUBSCRIBE_CAMPAIGN_ID
-        ),
-        'newsletter_subscription_un_email_template' => array(
-            self::XML_PATH_TRANSACTIONAL_NEWSLETTER_UNSUBSCRIBE_ENABLED,
-            self::XML_PATH_TRANSACTIONAL_NEWSLETTER_UNSUBSCRIBE_CAMPAIGN_ID
-        )
-    );
-
-    public static function getTransactionalEmailConfig() {
-        return self::$EMAIL_TEMPLATE_NAMES_TO_TRANSACTIONAL_EMAIL_OPTIONS;
-    }
-
-    private static $EMAIL_TEMPLATE_NAMES_TO_DISABLED_OPTIONS = array(
-        'sales_email_order_template' => self::XML_PATH_TRANSACTIONAL_ORDER_CONFIRM_DISABLED
-    );
-
-    public static function getDefaultEmailDisabledConfig() {
-        return self::$EMAIL_TEMPLATE_NAMES_TO_DISABLED_OPTIONS;
-    }
-
-    private function getDecodedMagentoApiToken() {
+    private function getDecodedMagentoApiToken()
+    {
         $magentoApiKey = Mage::getStoreConfig(self::XML_PATH_ITERABLE_API_KEY);
+
         return json_decode(base64_decode($magentoApiKey));
     }
 
-    private function getIterableApiToken() {
+    private function getIterableApiToken()
+    {
         $apiKeyJson = $this->getDecodedMagentoApiToken();
-        if ($apiKeyJson == NULL) {
-            return NULL;
+        if ($apiKeyJson == null) {
+            mage::throwException('API Key is not set');
         }
+
         return $apiKeyJson->t;
     }
-   
-    public function getNewsletterEmailListId() {
+
+    public function getNewsletterEmailListId()
+    {
         $apiKeyJson = $this->getDecodedMagentoApiToken();
-        if ($apiKeyJson == NULL) {
-            return NULL;
+        if ($apiKeyJson == null) {
+            return null;
         }
+
         return $apiKeyJson->n;
     }
 
-    public function getAccountEmailListId() {
+    public function getAccountEmailListId()
+    {
         $apiKeyJson = $this->getDecodedMagentoApiToken();
-        if ($apiKeyJson == NULL) {
-            return NULL;
+        if ($apiKeyJson == null) {
+            return null;
         }
+
         return $apiKeyJson->u;
     }
 
-    private function callIterableApi($event, $endpoint, $params) {
+    private function callIterableApi($event, $endpoint, $params)
+    {
         $eventsToTrack = Mage::getStoreConfig(self::XML_PATH_ENABLED_EVENTS);
         $eventsToTrack = explode(",", $eventsToTrack);
         if (!in_array($event, $eventsToTrack)) {
             Mage::log("Iterable: tracking disabled for event " . $event);
+
             // TODO - maybe run this before gathering data about the cart
             return null;
         }
         $apiKey = $this->getIterableApiToken();
-        if ($apiKey == NULL) {
+        if ($apiKey == null) {
             return null;
         }
         $url = "https://api.iterable.com/{$endpoint}?api_key={$apiKey}";
 //        $url = "http://localhost:9000{$endpoint}?api_key={$apiKey}";
         try {
             $client = new Zend_Http_Client($url);
-        } catch(Exception $e) {
+        } catch (Exception $e) {
             Mage::log("Warning: unable to create http client with url {$url} ({$e->getMessage()})");
+
             return null;
         }
         $client->setMethod(Zend_Http_Client::POST);
@@ -111,40 +74,52 @@ class Iterable_TrackOrderPlaced_Helper_Data extends Mage_Core_Helper_Abstract {
             $response = $client->request();
             $status = $response->getStatus();
             if ($status != 200) {
-                Mage::log("Iterable Tracker: Unable to track event at {$endpoint} with params {$json}; got status {$status} with body {$response->getBody()}");
+                Mage::log(
+                    "Iterable Tracker: Unable to track event at {$endpoint} with params {$json}; got status {$status} with body {$response->getBody()}"
+                );
             }
+
             return $response;
-        } catch(Exception $e) {
-            Mage::log("Warning: unable to send event at {$endpoint} with params {$json} to Iterable ({$e->getMessage()})");
+        } catch (Exception $e) {
+            Mage::log(
+                "Warning: unable to send event at {$endpoint} with params {$json} to Iterable ({$e->getMessage()})"
+            );
+
             return null;
         }
     }
 
-    public function getIp() {
+    public function getIp()
+    {
         return Mage::helper('core/http')->getRemoteAddr(false);
     }
 
-    public function setCurrentIp(&$dataFields) {
+    public function setCurrentIp(&$dataFields)
+    {
         if (!array_key_exists('ip', $dataFields)) {
             $dataFields['ip'] = $this->getIp();
         }
     }
 
-    public function updateUser($email, $dataFields=array(), $eventNameHint=null) {
+    public function updateUser($email, $dataFields = array(), $eventNameHint = null)
+    {
         $endpoint = '/api/users/update';
         $params = array(
             'email' => $email
         );
         $this->setCurrentIp($dataFields);
         $params['dataFields'] = $dataFields;
-        $eventName = isset($eventNameHint) ? $eventNameHint : Iterable_TrackOrderPlaced_Model_Trackingeventtypes::EVENT_TYPE_USER;
+        $eventName = isset($eventNameHint) ? $eventNameHint
+            : Iterable_TrackOrderPlaced_Model_Trackingeventtypes::EVENT_TYPE_USER;
+
         return $this->callIterableApi($eventName, $endpoint, $params);
     }
-    
-    public function subscribeEmailToList($email, $listId, $dataFields=array(), $resubscribe=False) {
+
+    public function subscribeEmailToList($email, $listId, $dataFields = array(), $resubscribe = false)
+    {
         $endpoint = '/api/lists/subscribe';
         $params = array(
-            'listId' => $listId,
+            'listId'      => $listId,
             'subscribers' => array(
                 array(
                     'email' => $email
@@ -155,13 +130,17 @@ class Iterable_TrackOrderPlaced_Helper_Data extends Mage_Core_Helper_Abstract {
         if (!empty($dataFields)) {
             $params['subscribers'][0]['dataFields'] = $dataFields;
         }
-        return $this->callIterableApi(Iterable_TrackOrderPlaced_Model_Trackingeventtypes::EVENT_TYPE_NEWSLETTER_SUBSCRIBE, $endpoint, $params);
+
+        return $this->callIterableApi(
+            Iterable_TrackOrderPlaced_Model_Trackingeventtypes::EVENT_TYPE_NEWSLETTER_SUBSCRIBE, $endpoint, $params
+        );
     }
-    
-    public function unsubscribeEmailFromList($email, $listId) {
+
+    public function unsubscribeEmailFromList($email, $listId)
+    {
         $endpoint = '/api/lists/unsubscribe';
         $params = array(
-            'listId' => $listId,
+            'listId'      => $listId,
             'subscribers' => array(
                 array(
                     'email' => $email
@@ -169,25 +148,31 @@ class Iterable_TrackOrderPlaced_Helper_Data extends Mage_Core_Helper_Abstract {
             )
             // 'campaignId' => iterableCid cookie?
         );
-        return $this->callIterableApi(Iterable_TrackOrderPlaced_Model_Trackingeventtypes::EVENT_TYPE_NEWSLETTER_UNSUBSCRIBE, $endpoint, $params);
+
+        return $this->callIterableApi(
+            Iterable_TrackOrderPlaced_Model_Trackingeventtypes::EVENT_TYPE_NEWSLETTER_UNSUBSCRIBE, $endpoint, $params
+        );
     }
 
-    public function track($event, $email, $dataFields=array()) {
+    public function track($event, $email, $dataFields = array())
+    {
         $endpoint = '/api/events/track';
         $params = array(
-            'email' => $email,
+            'email'     => $email,
             'eventName' => $event
-        );            
+        );
         if (!empty($dataFields)) {
             $params['dataFields'] = $dataFields;
         }
+
         return $this->callIterableApi($event, $endpoint, $params);
     }
 
-    public function updateCart($email, $items, $dataFields=array()) {
+    public function updateCart($email, $items, $dataFields = array())
+    {
         $endpoint = '/api/commerce/updateCart';
         $params = array(
-            'user' => array(
+            'user'  => array(
                 'email' => $email
             ),
             'items' => $items
@@ -195,13 +180,19 @@ class Iterable_TrackOrderPlaced_Helper_Data extends Mage_Core_Helper_Abstract {
         if (!empty($dataFields)) {
             $params['user']['dataFields'] = $dataFields;
         }
-        return $this->callIterableApi(Iterable_TrackOrderPlaced_Model_Trackingeventtypes::EVENT_TYPE_CART_UPDATED, $endpoint, $params);
+
+        return $this->callIterableApi(
+            Iterable_TrackOrderPlaced_Model_Trackingeventtypes::EVENT_TYPE_CART_UPDATED, $endpoint, $params
+        );
     }
 
-    public function trackPurchase($email, $items, $total, $campaignId=NULL, $templateId=NULL, $dataFields=array(), $customerDataFields=array()) {
+    public function trackPurchase(
+        $email, $items, $total, $campaignId = null, $templateId = null, $dataFields = array(),
+        $customerDataFields = array()
+    ) {
         $endpoint = '/api/commerce/trackPurchase';
         $params = array(
-            'user' => array(
+            'user'  => array(
                 'email' => $email
             ),
             'items' => $items,
@@ -213,28 +204,36 @@ class Iterable_TrackOrderPlaced_Helper_Data extends Mage_Core_Helper_Abstract {
         if (!empty($customerDataFields)) {
             $params['user']['dataFields'] = $customerDataFields;
         }
-        if ($campaignId != NULL) {
+        if ($campaignId != null) {
             $params['campaignId'] = $campaignId;
         }
-        if ($templateId != NULL) {
+        if ($templateId != null) {
             $params['templateId'] = $templateId;
         }
-        return $this->callIterableApi(Iterable_TrackOrderPlaced_Model_Trackingeventtypes::EVENT_TYPE_ORDER, $endpoint, $params);
+
+        return $this->callIterableApi(
+            Iterable_TrackOrderPlaced_Model_Trackingeventtypes::EVENT_TYPE_ORDER, $endpoint, $params
+        );
     }
 
-    public function triggerCampaign($email, $campaignId, $dataFields=NULL) {
+    public function triggerCampaign($email, $campaignId, $dataFields = null)
+    {
         $endpoint = '/api/email/target';
         $params = array(
             'recipientEmail' => $email,
-            'campaignId' => $campaignId
+            'campaignId'     => $campaignId
         );
-        if (! is_null($dataFields)) {
+        if (!is_null($dataFields)) {
             $params['dataFields'] = $dataFields;
         }
-        return $this->callIterableApi(Iterable_TrackOrderPlaced_Model_Trackingeventtypes::EVENT_TYPE_TRIGGER_EMAIL, $endpoint, $params);
+
+        return $this->callIterableApi(
+            Iterable_TrackOrderPlaced_Model_Trackingeventtypes::EVENT_TYPE_TRIGGER_EMAIL, $endpoint, $params
+        );
     }
 
-    public function trackShipment($email, $shipment) {
+    public function trackShipment($email, $shipment)
+    {
         return $this->track(Iterable_TrackOrderPlaced_Model_Trackingeventtypes::EVENT_TYPE_SHIPMENT, $email, $shipment);
     }
 
@@ -245,8 +244,10 @@ class Iterable_TrackOrderPlaced_Helper_Data extends Mage_Core_Helper_Abstract {
 
     public function trackWishlist($email, $wishlist)
     {
-        return $this->updateUser($email, array(
+        return $this->updateUser(
+            $email, array(
             'wishlist' => $wishlist
-        ), Iterable_TrackOrderPlaced_Model_Trackingeventtypes::EVENT_TYPE_WISHLIST_ADD_PRODUCT);
+        ), Iterable_TrackOrderPlaced_Model_Trackingeventtypes::EVENT_TYPE_WISHLIST_ADD_PRODUCT
+        );
     }
 }

--- a/app/code/community/Iterable/TrackOrderPlaced/Model/Email/Template.php
+++ b/app/code/community/Iterable/TrackOrderPlaced/Model/Email/Template.php
@@ -6,7 +6,7 @@
  *
  * @author Lucas van Staden (sales@proxiblue.com.au)
  */
-class Iterable_TrackOrderPlaced_Model_Email_Template extends Aschroder_SMTPPro_Model_Email_Template
+class Iterable_TrackOrderPlaced_Model_Email_Template extends Mage_Core_Model_Email_Template 
 {
 
     /**

--- a/app/code/community/Iterable/TrackOrderPlaced/Model/Email/Template.php
+++ b/app/code/community/Iterable/TrackOrderPlaced/Model/Email/Template.php
@@ -4,6 +4,7 @@
  * This class overwrites Magento's default send functionality by routing all
  * emails through Iterable using the Send API call.
  *
+ * @author Lucas van Staden (sales@proxiblue.com.au)
  */
 class Iterable_TrackOrderPlaced_Model_Email_Template extends Aschroder_SMTPPro_Model_Email_Template
 {
@@ -49,7 +50,7 @@ class Iterable_TrackOrderPlaced_Model_Email_Template extends Aschroder_SMTPPro_M
                                 . $iterableCampaignId
                                 . "; sending default Magento email"
                             );
-                            parent::send($email, null, $variables);
+                            parent::send($email, $name, $variables);
                         }
                     } catch (Exception $e) {
                         Mage::logException($e);
@@ -63,7 +64,7 @@ class Iterable_TrackOrderPlaced_Model_Email_Template extends Aschroder_SMTPPro_M
             }
         }
         // default, send normal
-        parent::send($email, null, $variables);
+        parent::send($email, $name, $variables);
     }
 
 }

--- a/app/code/community/Iterable/TrackOrderPlaced/Model/Email/Template.php
+++ b/app/code/community/Iterable/TrackOrderPlaced/Model/Email/Template.php
@@ -4,10 +4,11 @@
  * This class overwrites Magento's default send functionality by routing all
  * emails through Iterable using the Send API call.
  *
- * @author Lucas van Staden (sales@proxiblue.com.au)
  */
-class Iterable_TrackOrderPlaced_Model_Email_Template extends Mage_Core_Model_Email_Template 
+class Iterable_TrackOrderPlaced_Model_Email_Template extends Mage_Core_Model_Email_Template
 {
+
+    protected $_helper;
 
     /**
      * Send mail to recipient
@@ -20,53 +21,146 @@ class Iterable_TrackOrderPlaced_Model_Email_Template extends Mage_Core_Model_Ema
      **/
     public function send($email, $name = null, array $variables = array())
     {
-        $helper = Mage::helper('trackorderplaced');
+        $this->_helper = Mage::helper('trackorderplaced');
 
-        $interceptMap = unserialize(Mage::getStoreConfig('transactional_email_options/intercept/list'));
+        // events take precedence.
+
+        $templateCode = ($this->getTemplateCode()) ? $this->getTemplateCode() : $this->getTemplateId();
+
+        $intercept = unserialize(Mage::getStoreConfig('transactional_email_options/events/intercept'));
         $cleanMap = array();
-        if (is_array($interceptMap) && count($interceptMap) > 0) {
-            foreach ($interceptMap as $map) {
-                $cleanMap = array($map['template'] => $map['campaign_id']);
+        if (is_array($intercept) && count($intercept) > 0) {
+            foreach ($intercept as $map) {
+                $cleanMap = array($map['template'] => array('campaign_id' => $map['campaign_id'],
+                                                            'template_id' => $map['template_id'],
+                                                            'event_name'  => $map['event_name']));
             }
         }
-        if (array_key_exists($this->getTemplateCode(), $cleanMap)) {
-            try {
-                $iterableCampaignId = (int)$cleanMap[$this->getTemplateCode()];
-
-                if (empty($iterableCampaignId)) {
-                    return parent::send($email, $name, $variables);
+        if (array_key_exists($templateCode, $cleanMap)) {
+            $result = $this->_sendAsEvent($email, $name, $variables, $cleanMap);
+            if (!is_null($result)) {
+                return $result;
+            }
+        } else {
+            $intercept = unserialize(Mage::getStoreConfig('transactional_email_options/campaigns/intercept'));
+            $cleanMap = array();
+            if (is_array($intercept) && count($intercept) > 0) {
+                foreach ($intercept as $map) {
+                    $cleanMap = array($map['template'] => $map['campaign_id']);
+                }
+            }
+            if (array_key_exists($templateCode, $cleanMap)) {
+                $result = $this->_sendAsCampaign($email, $name, $variables, $cleanMap);
+                if (!is_null($result)) {
+                    return $result;
                 }
 
-                // email and name can be either arrays or strings; we don't care about the name though
-                $emails = array_values((array)$email);
+            }
+        }
 
-                $anyFailures = false;
-                foreach ($emails as $email) {
-                    try {
-                        $response = $helper->triggerCampaign($email, $iterableCampaignId);
-                        if (is_null($response) || ($response->getStatus() != 200)) {
-                            Mage::log(
-                                "Unable to trigger Iterable email for user " . $email . " and campaign "
-                                . $iterableCampaignId
-                                . "; sending default Magento email"
-                            );
-                            parent::send($email, $name, $variables);
-                        }
-                    } catch (Exception $e) {
-                        Mage::logException($e);
-                        $anyFailures = true;
+        // the fallback default
+
+        return parent::send($email, $name, $variables);
+
+    }
+
+
+    /**
+     * Email intercepted to event
+     *
+     * @param   array|string      $email     E-mail(s)
+     * @param   array|string|null $name      receiver name(s)
+     * @param   array             $variables template variables
+     * @param   array             $cleanMap  admin config data
+     *
+     * @return bool
+     */
+    private function _sendAsEvent($email, $name = null, array $variables = array(), $cleanMap = array())
+    {
+        try {
+            // the default event name is the template code
+            $eventName = ($this->getTemplateCode()) ? $this->getTemplateCode() : $this->getTemplateId();
+            if (array_key_exists('event_name', $cleanMap[$eventName]) && !empty($cleanMap[$eventName]['event_name'])) {
+                $eventName = $cleanMap[$eventName]['event_name'];
+            }
+            $campaignId = null;
+            if (array_key_exists('campaign_id', $cleanMap[$eventName])
+                && !empty($cleanMap[$eventName]['campaign_id'])
+            ) {
+                $campaignId = $cleanMap[$eventName]['campaign_id'];
+            }
+            $templateId = null;
+            if (array_key_exists('template_id', $cleanMap[$eventName])
+                && !empty($cleanMap[$eventName]['template_id'])
+            ) {
+                $templateId = $cleanMap[$eventName]['template_id'];
+            }
+            $variables['name'] = $name;
+            unset($variables['store']);
+            if (array_key_exists('data', $variables)) {
+                if ($variables['data'] instanceof Varien_Object) {
+                    $data = $variables['data']->getData();
+                }
+            }
+            $dataFields = array_merge($variables, $data);
+            unset($dataFields['data']);
+
+            return $this->_helper->track($eventName, $email, $dataFields, $campaignId, $templateId, true);
+
+        } catch (Exception $e) {
+            mage::logException($e);
+
+            return parent::send($email, $name, $variables);
+        }
+
+        return true;
+    }
+
+
+    /**
+     * EMail intercepted as campaign
+     *
+     * @param   array|string      $email     E-mail(s)
+     * @param   array|string|null $name      receiver name(s)
+     * @param   array             $variables template variables
+     * @param   array             $cleanMap  admin config data
+     *
+     * @return bool
+     */
+    private function _sendAsCampaign($email, $name = null, array $variables = array(), $cleanMap = array())
+    {
+        try {
+            $campaignId = (int)$cleanMap[$this->getTemplateCode()];
+
+            if (empty($campaignId)) {
+                return parent::send($email, $name, $variables);
+            }
+
+            // email and name can be either arrays or strings; we don't care about the name though
+            $emails = array_values((array)$email);
+
+            $anyFailures = false;
+            foreach ($emails as $email) {
+                try {
+                    $response = $this->_helper->triggerCampaign($email, $campaignId);
+                    if (is_null($response) || ($response->getStatus() != 200)) {
+                        Mage::log(
+                            "Unable to trigger Iterable email for user " . $email . " and campaign "
+                            . $campaignId
+                            . "; sending default Magento email"
+                        );
+                        parent::send($email, null, $variables);
                     }
+                } catch (Exception $e) {
+                    Mage::logException($e);
+                    $anyFailures = true;
                 }
-
-                return !$anyFailures;
-            } catch (Exception $e) {
-                mage::logException($e);
             }
+
+            return !$anyFailures;
+        } catch (Exception $e) {
+            mage::logException($e);
         }
-        // default, send normal
-        parent::send($email, $name, $variables);
     }
 
 }
-
-?>

--- a/app/code/community/Iterable/TrackOrderPlaced/Model/Email/Template.php
+++ b/app/code/community/Iterable/TrackOrderPlaced/Model/Email/Template.php
@@ -1,74 +1,71 @@
 <?php
+
 /**
  * This class overwrites Magento's default send functionality by routing all
  * emails through Iterable using the Send API call.
- * 
- * @author    Iterable
+ *
  */
-class Iterable_TrackOrderPlaced_Model_Email_Template extends Mage_Core_Model_Email_Template {
-
-    private function getIterableCampaignIdForTemplateName($templateName) {
-        $transactionalEmailConfig = Mage::helper('trackorderplaced')->getTransactionalEmailConfig();
-        if (array_key_exists($templateName, $transactionalEmailConfig)) {
-            // if there's something for this template, check whether it's enabled and return the id if so
-            list($enabled_cfg, $iterable_campaign_id_cfg) = $transactionalEmailConfig[$templateName];
-            return Mage::getStoreConfig($enabled_cfg) ? intval(Mage::getStoreConfig($iterable_campaign_id_cfg)): null;
-        } else {
-            // if there's nothing for this template don't send through Iterable
-            return null;
-        }
-    }
-
-    private function isDefaultSendingDisabledForTemplateName($templateName) {
-        $disabledTemplateConfig = Mage::helper('trackorderplaced')->getDefaultEmailDisabledConfig();
-        return
-            array_key_exists($templateName, $disabledTemplateConfig) &&
-            intval(Mage::getStoreConfig($disabledTemplateConfig[$templateName]));
-    }
+class Iterable_TrackOrderPlaced_Model_Email_Template extends Aschroder_SMTPPro_Model_Email_Template
+{
 
     /**
      * Send mail to recipient
      *
-     * @param   array|string       $email        E-mail(s)
-     * @param   array|string|null  $name         receiver name(s)
-     * @param   array              $variables    template variables
+     * @param   array|string      $email     E-mail(s)
+     * @param   array|string|null $name      receiver name(s)
+     * @param   array             $variables template variables
+     *
      * @return  boolean
      **/
-    public function send($email, $name = null, array $variables = array()) 
+    public function send($email, $name = null, array $variables = array())
     {
         $helper = Mage::helper('trackorderplaced');
 
-        $template_name = $this->getId();
-        if ($this->isDefaultSendingDisabledForTemplateName($template_name)) {
-//            Mage::log("Suppressing default email for " . $template_name . " due to Iterable config");
-            return true;
-        }
-        $iterable_campaign_id = $this->getIterableCampaignIdForTemplateName($template_name);
-
-        if (empty($iterable_campaign_id)) {
-//            Mage::log("Not sending " . $template_name . " through Iterable");
-            return parent::send($email, $name, $variables);
-        }
-
-        // email and name can be either arrays or strings; we don't care about the name though
-        $emails = array_values((array)$email);
-
-        $anyFailures = false;
-        foreach ($emails as $email) {
-            try {
-                $response = $helper->triggerCampaign($email, $iterable_campaign_id);
-                if (is_null($response) || ($response->getStatus() != 200)) {
-                    Mage::log("Unable to trigger Iterable email for user " . $email . " and campaign " . $iterable_campaign_id . "; sending default Magento email");
-                    parent::send($email, null, $variables);
-                }
-            } catch (Exception $e) {
-                Mage::logException($e);
-                $anyFailures = true;
+        $interceptMap = unserialize(Mage::getStoreConfig('transactional_email_options/intercept/list'));
+        $cleanMap = array();
+        if (is_array($interceptMap) && count($interceptMap) > 0) {
+            foreach ($interceptMap as $map) {
+                $cleanMap = array($map['template'] => $map['campaign_id']);
             }
         }
+        if (array_key_exists($this->getTemplateCode(), $cleanMap)) {
+            try {
+                $iterableCampaignId = (int)$cleanMap[$this->getTemplateCode()];
 
-        return ! $anyFailures;
-    } 
+                if (empty($iterableCampaignId)) {
+                    return parent::send($email, $name, $variables);
+                }
+
+                // email and name can be either arrays or strings; we don't care about the name though
+                $emails = array_values((array)$email);
+
+                $anyFailures = false;
+                foreach ($emails as $email) {
+                    try {
+                        $response = $helper->triggerCampaign($email, $iterableCampaignId);
+                        if (is_null($response) || ($response->getStatus() != 200)) {
+                            Mage::log(
+                                "Unable to trigger Iterable email for user " . $email . " and campaign "
+                                . $iterableCampaignId
+                                . "; sending default Magento email"
+                            );
+                            parent::send($email, null, $variables);
+                        }
+                    } catch (Exception $e) {
+                        Mage::logException($e);
+                        $anyFailures = true;
+                    }
+                }
+
+                return !$anyFailures;
+            } catch (Exception $e) {
+                mage::logException($e);
+            }
+        }
+        // default, send normal
+        parent::send($email, null, $variables);
+    }
 
 }
+
 ?>

--- a/app/code/community/Iterable/TrackOrderPlaced/Model/Observer.php
+++ b/app/code/community/Iterable/TrackOrderPlaced/Model/Observer.php
@@ -64,12 +64,12 @@ class Iterable_TrackOrderPlaced_Model_Observer
             $product = Mage::getModel('catalog/product')->load($item->getProductId());
         }
         $typeId = $product->getTypeId();
-        
+
         if ($isOrder) {
             $price = $item->getPrice();
             $quantity = $item->getQtyOrdered();
         } elseif ($isQuote) {
-            $price = $item->getCalculationPrice(); 
+            $price = $item->getCalculationPrice();
             $quantity = $item->getQty();
         } else {
             $price = ($typeId == Mage_Catalog_Model_Product_Type::TYPE_BUNDLE) ?
@@ -78,7 +78,7 @@ class Iterable_TrackOrderPlaced_Model_Observer
                 $product->getPrice();
             $quantity = intval($product->getCartQty());
         }
-        
+
         $imageUrl = Mage::getBaseUrl(Mage_Core_Model_Store::URL_TYPE_MEDIA).'catalog/product/'.$product->getImage();
         $thumbnailUrl = Mage::getModel('catalog/product_media_config')->getMediaUrl($product->getThumbnail());
         $categoryNames = array();
@@ -103,7 +103,7 @@ class Iterable_TrackOrderPlaced_Model_Observer
     }
 
     public function getItemsFromQuote($quote=NULL, $includeConfigurableSubproducts=TRUE)
-    { 
+    {
         if ($quote == NULL) {
             $quote = Mage::getSingleton('checkout/session')->getQuote();
         }
@@ -139,7 +139,7 @@ class Iterable_TrackOrderPlaced_Model_Observer
         }
         $customer = Mage::getSingleton('customer/session')->getCustomer();
         $helper = Mage::helper('trackorderplaced');
-        $helper->updateCart($customer->getEmail(), $items); 
+        $helper->updateCart($customer->getEmail(), $items);
     }
 
     /**
@@ -151,7 +151,7 @@ class Iterable_TrackOrderPlaced_Model_Observer
         $quote = $observer->getEvent()->getQuoteItem()->getQuote();
         $quote->collectTotals();
         $quote->save();
-        
+
         $this->sendCartUpdated();
     }
 
@@ -175,7 +175,7 @@ class Iterable_TrackOrderPlaced_Model_Observer
         $this->sendCartUpdated();
     }
 
-    /** 
+    /**
      * Called when something is removed from the cart (for example via the trash can symbol on cart page)
      * Unforunately it also gets called on updateItems with quantity = 0, or when you reconfigure a configurable product with different options (so we'll get a few extra events)
      */
@@ -183,7 +183,7 @@ class Iterable_TrackOrderPlaced_Model_Observer
     {
         $this->sendCartUpdated();
     }
-    
+
     /**
      * Gets fired before the quote is saved. Seems to happen on changes to cart, in addition to whenever we view it
      * There doesn't seem to be any event called when the user clicks "Clear Shopping Cart", so hook into this and check what they clicked
@@ -335,10 +335,10 @@ class Iterable_TrackOrderPlaced_Model_Observer
      * Gets called when a customer saves their data
      * Also seems to get called at several other times (after an order, etc)
      */
-    public function customerSaveAfter(Varien_Event_Observer $observer) 
+    public function customerSaveAfter(Varien_Event_Observer $observer)
     {
         $customer = $observer->getCustomer();
-        
+
         $email = $customer->getEmail();
 
         $dataFields = $customer->getData();
@@ -353,7 +353,7 @@ class Iterable_TrackOrderPlaced_Model_Observer
         $defaultBilling = $customer->getDefaultBillingAddress();
         if ($defaultBilling) { $dataFields['defaultBilling'] = $defaultBilling->getData(); }
         // unset password/conf... unset created_at because that never changes, and it's in a bad format to boot
-        $fieldsToUnset = array('password', 'password_hash', 'confirmation', 'subscriber_confirm_code', 'created_at'); 
+        $fieldsToUnset = array('password', 'password_hash', 'confirmation', 'subscriber_confirm_code', 'created_at');
         foreach ($fieldsToUnset as $fieldToUnset) {
             if (array_key_exists($fieldToUnset, $dataFields)) {
                 unset($dataFields[$fieldToUnset]);
@@ -372,7 +372,7 @@ class Iterable_TrackOrderPlaced_Model_Observer
         if (!$customer->getOrigData()) {
             $listId = $helper->getAccountEmailListId();
             if ($listId != NULL) {
-                $helper->subscribeEmailToList($email, $listId, $dataFields); 
+                $helper->subscribeEmailToList($email, $listId, $dataFields);
             }
         }
     }
@@ -431,7 +431,7 @@ class Iterable_TrackOrderPlaced_Model_Observer
     }
     */
 
-    /** 
+    /**
      * Called whenever a newsletter subscriber is saved
      */
     public function newsletterSubscriberSaveAfter(Varien_Event_Observer $observer)

--- a/app/code/community/Iterable/TrackOrderPlaced/etc/config.xml
+++ b/app/code/community/Iterable/TrackOrderPlaced/etc/config.xml
@@ -33,18 +33,25 @@
             </trackorderplaced>
         </helpers>
 
+        <blocks>
+            <trackorderplaced>
+                <class>Iterable_TrackOrderPlaced_Block</class>
+            </trackorderplaced>
+        </blocks>
+
         <models>
             <iterable_trackorderplaced>
                 <class>Iterable_TrackOrderPlaced_Model</class>
             </iterable_trackorderplaced>
 
-            <!-- disabled for now for Memebox; clashes with CustomSMTP
+            <!-- extends Aschroder_SMTPPro_Model_Email_Template -->
+            <!-- if removed, Aschroder_SMTPPro_Model_Email_Template must again rewrite this class -->
             <core>
                 <rewrite>
                     <email_template>Iterable_TrackOrderPlaced_Model_Email_Template</email_template>
                 </rewrite>
             </core>
-            -->
+
         </models>
 
         <!-- Defining an event observer -->

--- a/app/code/community/Iterable/TrackOrderPlaced/etc/system.xml
+++ b/app/code/community/Iterable/TrackOrderPlaced/etc/system.xml
@@ -48,26 +48,46 @@
             <show_in_website>1</show_in_website>
             <show_in_store>1</show_in_store>
             <groups>
-                <intercept translate="label">
-                    <label>Event Tracking</label>
+                <campaigns translate="label">
+                    <label>Campaigns</label>
                     <frontend_type>text</frontend_type>
                     <sort_order>2</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
                     <show_in_store>1</show_in_store>
                     <fields>
-                        <list translate="label">
+                        <intercept translate="label">
                             <label>Transaction Emails to intercept into campaigns</label>
-                            <frontend_model>trackorderplaced/adminhtml_system_config_form_field_interceptlist</frontend_model>
+                            <frontend_model>trackorderplaced/adminhtml_system_config_form_field_campaigns</frontend_model>
                             <backend_model>adminhtml/system_config_backend_serialized_array</backend_model>
                             <sort_order>100</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                             <comment><![CDATA[Intercept these emails and initiate a campaign]]></comment>
-                        </list>
+                        </intercept>
                     </fields>
-                </intercept>
+                </campaigns>
+                <events translate="label">
+                    <label>Events</label>
+                    <frontend_type>text</frontend_type>
+                    <sort_order>1</sort_order>
+                    <show_in_default>1</show_in_default>
+                    <show_in_website>1</show_in_website>
+                    <show_in_store>1</show_in_store>
+                    <fields>
+                        <intercept translate="label">
+                            <label>Transaction Emails to intercept into events</label>
+                            <frontend_model>trackorderplaced/adminhtml_system_config_form_field_events</frontend_model>
+                            <backend_model>adminhtml/system_config_backend_serialized_array</backend_model>
+                            <sort_order>100</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment><![CDATA[Intercept these emails and push tracking data]]></comment>
+                        </intercept>
+                    </fields>
+                </events>
             </groups>
         </transactional_email_options>
         <advanced_options>

--- a/app/code/community/Iterable/TrackOrderPlaced/etc/system.xml
+++ b/app/code/community/Iterable/TrackOrderPlaced/etc/system.xml
@@ -3,7 +3,8 @@
         <iterableconfig translate="label" module="trackorderplaced">
             <label><![CDATA[<div>Iterable</div>]]></label>
             <class>iterable-section</class>
-            <sort_order>101</sort_order> <!-- General is 100, from app/code/core/Mage/Core/etc/system.xml -->
+            <sort_order>101</sort_order>
+            <!-- General is 100, from app/code/core/Mage/Core/etc/system.xml -->
         </iterableconfig>
     </tabs>
     <sections> <!-- each section defined here is a subcategory of a heading from tabs. EACH SECTION NEEDS AN ACL DEFINED IN CONFIG.XML -->
@@ -47,146 +48,26 @@
             <show_in_website>1</show_in_website>
             <show_in_store>1</show_in_store>
             <groups>
-                <account_created translate="label">
-                    <label>Account Created</label>
-                    <frontend_type>text</frontend_type>
-                    <sort_order>1</sort_order>
-                    <show_in_default>1</show_in_default>
-                    <show_in_website>1</show_in_website>
-                    <show_in_store>1</show_in_store>
-                    <fields>
-                        <is_enabled>
-                            <label>Enabled</label>
-                            <comment>Send account creation emails through Iterable</comment>
-                            <frontend_type>select</frontend_type>
-                            <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>1</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                        </is_enabled>
-                        <campaign_id>
-                            <label>Triggered Campaign Id</label>
-                            <comment>Id of the Triggered Email Campaign to send when a user creates an account</comment>
-                            <frontend_type>text</frontend_type>
-                            <validate>validate-number</validate>
-                            <sort_order>2</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                        </campaign_id>
-                    </fields>
-                </account_created>
-                <forgot_password translate="label">
-                    <label>Forgot Password</label>
+                <intercept translate="label">
+                    <label>Event Tracking</label>
                     <frontend_type>text</frontend_type>
                     <sort_order>2</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
                     <show_in_store>1</show_in_store>
                     <fields>
-                        <is_enabled>
-                            <label>Enabled</label>
-                            <comment>Send password reset emails through Iterable</comment>
-                            <frontend_type>select</frontend_type>
-                            <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>1</sort_order>
+                        <list translate="label">
+                            <label>Transaction Emails to intercept into campaigns</label>
+                            <frontend_model>trackorderplaced/adminhtml_system_config_form_field_interceptlist</frontend_model>
+                            <backend_model>adminhtml/system_config_backend_serialized_array</backend_model>
+                            <sort_order>100</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
-                        </is_enabled>
-                        <campaign_id>
-                            <label>Triggered Campaign Id</label>
-                            <comment>Id of the Triggered Email Campaign to send when a user resets their password</comment>
-                            <frontend_type>text</frontend_type>
-                            <validate>validate-number</validate>
-                            <sort_order>2</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                        </campaign_id>
+                            <comment><![CDATA[Intercept these emails and initiate a campaign]]></comment>
+                        </list>
                     </fields>
-                </forgot_password>
-                <newsletter_subscribe translate="label">
-                    <label>Newsletter Subscribes</label>
-                    <frontend_type>text</frontend_type>
-                    <sort_order>3</sort_order>
-                    <show_in_default>1</show_in_default>
-                    <show_in_website>1</show_in_website>
-                    <show_in_store>1</show_in_store>
-                    <fields>
-                        <is_enabled>
-                            <label>Enabled</label>
-                            <comment>Send newsletter subscription emails through Iterable</comment>
-                            <frontend_type>select</frontend_type>
-                            <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>1</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                        </is_enabled>
-                        <campaign_id>
-                            <label>Triggered Campaign Id</label>
-                            <comment>Id of the Triggered Email Campaign to send when a user subscribes to a newsletter</comment>
-                            <frontend_type>text</frontend_type>
-                            <validate>validate-number</validate>
-                            <sort_order>2</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                        </campaign_id>
-                    </fields>
-                </newsletter_subscribe>
-                <newsletter_unsubscribe translate="label">
-                    <label>Newsletter Unsubscribes</label>
-                    <frontend_type>text</frontend_type>
-                    <sort_order>4</sort_order>
-                    <show_in_default>1</show_in_default>
-                    <show_in_website>1</show_in_website>
-                    <show_in_store>1</show_in_store>
-                    <fields>
-                        <is_enabled>
-                            <label>Enabled</label>
-                            <comment>Send newsletter unsubscription emails through Iterable</comment>
-                            <frontend_type>select</frontend_type>
-                            <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>1</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                        </is_enabled>
-                        <campaign_id>
-                            <label>Triggered Campaign Id</label>
-                            <comment>Id of the Triggered Email Campaign to send when a user unsubscribes from a newsletter</comment>
-                            <frontend_type>text</frontend_type>
-                            <validate>validate-number</validate>
-                            <sort_order>2</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                        </campaign_id>
-                    </fields>
-                </newsletter_unsubscribe>
-                <order_confirm translate="label">
-                    <label>Order Confirmations</label>
-                    <frontend_type>text</frontend_type>
-                    <sort_order>5</sort_order>
-                    <show_in_default>1</show_in_default>
-                    <show_in_website>1</show_in_website>
-                    <show_in_store>1</show_in_store>
-                    <fields>
-                        <is_disabled>
-                            <label>Disabled</label>
-                            <comment>Suppress default order confirmation emails from Magento. Make sure you set up an appropriate workflow in Iterable first!</comment>
-                            <frontend_type>select</frontend_type>
-                            <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>1</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                        </is_disabled>
-                    </fields>
-                </order_confirm>
+                </intercept>
             </groups>
         </transactional_email_options>
         <advanced_options>


### PR DESCRIPTION
The current iterable extension is limited in which templates can be sent to campaigns.

This merge propose improvement to allow any magento transactional email to be intercepted, and diverted to an iterable campaign, simply by using a template => campaign id configurable map in admin.

If a transactional email  (designated by template name) exists in the map, and has a valid campaign id, it will be diverted to the given campaign, and not sent as a normal transactional email.
The transactional magento email is used as a fallback, in case there is an issue.

This requires the rewrite for core email sending of class  Mage_Core_Model_Email_Template to be enabled 

``` xml
<core>
    <rewrite>
       <email_template>Iterable_TrackOrderPlaced_Model_Email_Template</email_template>
    </rewrite>
</core>
```

Care must be taken to ensure that no other extension exists that also rewrites that class.
An example of this can be 'Aschroder_SMTPPro'

If there is a rewrite conflict, it is vital that the conflict is addressed in the manner that iterable extension rewrites the core class, and have the iterable class to extend the other extension template class
This is to ensure that the iterable extension first determines if the email must be diverted, before passing code flow to the other (or core) class

An example to resolve the conflict with  Aschroder_SMTPPro:
- Edit /app/code/community/Aschroder/SMTPPro/etc/config.xml and remove rewrite directive

``` xml
<core>
   <rewrite>
    <email>Aschroder_SMTPPro_Model_Email</email>
        <mail_template>Aschroder_SMTPPro_Model_Email_Template</email_template>
   </rewrite>
</core>
```

will become 

``` xml
<core>
   <rewrite>
    <email>Aschroder_SMTPPro_Model_Email</email>
        <!-- CONFLICT RESOLUTION -->
            <!-- Iterable extension needs to rewrite this core class first ->
        <!--<email_template>Aschroder_SMTPPro_Model_Email_Template</email_template>-->
  </rewrite>
</core>
```

Next make the iterable extension class   `Iterable_TrackOrderPlaced_Model_Email_Template` extend the class `Aschroder_SMTPPro_Model_Email_Template`

Now, the core class is rewritten by iterable, dealt with by iterable logic, and if need be flow is passed to the Aschroder_SMTPPro (or core) extension.
